### PR TITLE
Fix TypeError raised when state_file is default.

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -29,7 +29,7 @@ module Fluent
     config_param :username, :string, :default => nil
     config_param :password, :string, :default => nil
 
-    config_param :state_file, :string, :default => nil
+    config_param :state_file, :string, :default => ''
     config_param :tag_prefix, :string, :default => nil
     config_param :select_interval, :time, :default => 60
     config_param :select_limit, :time, :default => 500


### PR DESCRIPTION
File.exist?(nil) causes TypeError. To fix this, change
default value to ''.