### PR TITLE
Remove state_file warning to SQLOutput.

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -48,11 +48,6 @@ module Fluent
 
       def configure(conf)
         super
-
-        unless @state_file
-          $log.warn "'state_file PATH' parameter is not set to a 'sql' source."
-          $log.warn "this parameter is highly recommended to save the last rows to resume tailing."
-        end
       end
 
       def init(tag_prefix, base_model)
@@ -132,6 +127,11 @@ module Fluent
 
     def configure(conf)
       super
+
+      unless @state_file
+        $log.warn "'state_file PATH' parameter is not set to a 'sql' source."
+        $log.warn "this parameter is highly recommended to save the last rows to resume tailing."
+      end
 
       @tables = conf.elements.select {|e|
         e.name == 'table'


### PR DESCRIPTION
Now if state_file is set on <source>, warning is raised.
To fix this, remove state_file from TableElement to SQLOutput.
