### PR TITLE
fix doesn't occure error when refer empty table

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -125,7 +125,7 @@ module Fluent
           end
         end
 
-        last_record = last_record.dup  # some plugin rewrites record :(
+        last_record = last_record.dup if last_record  # some plugin rewrites record :(
         @router.emit_stream(@tag, me)
 
         return last_record


### PR DESCRIPTION
I noticed when using this plugin. Error log would have been output if this plugin refer empty table. When just started using, output log file lots error message.
I modify it because this is not error when table is empty.

Example error message when refer empty table.
2015-12-13 05:44:40 +0000 [error]: unexpected error error="can't dup NilClass" error_class=TypeError
2015-12-13 05:44:40 +0000 [error]: suppressed same stacktrace