### PR TITLE
in_sql waits until current select statement has been emitted

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -237,6 +237,8 @@ module Fluent
 
     def shutdown
       @stop_flag = true
+      $log.debug "Waiting for thread to finish"
+      @thread.join
     end
 
     def thread_main


### PR DESCRIPTION
I noticed a corrupt (empty) sql statefile in some cases, when fluentd received a SIGINT or shutdown command while the thread was selecting from database or emitting records.
It is easy reproducible with a 1s refresh interval and 1000 rows. The sql state file will be empty and the whole table will be read again, causing duplicate messages to be emitted.

With my PR, the sql plugin will exit after the rows have been emitted and the statefile was updated, allowing a clean exit.