### PR TITLE
Add enable_fallback option

### DIFF
--- a/lib/fluent/plugin/out_sql.rb
+++ b/lib/fluent/plugin/out_sql.rb
@@ -49,10 +49,11 @@ module Fluent
       attr_reader :model
       attr_reader :pattern
 
-      def initialize(pattern, log)
+      def initialize(pattern, log, enable_fallback)
         super()
         @pattern = MatchPattern.create(pattern)
         @log = log
+        @enable_fallback = enable_fallback
       end
 
       def configure(conf)
@@ -162,7 +163,7 @@ module Fluent
       conf.elements.select { |e|
         e.name == 'table'
       }.each { |e|
-        te = TableElement.new(e.arg, log)
+        te = TableElement.new(e.arg, log, @enable_fallback)
         te.configure(e)
         if e.arg.empty?
           $log.warn "Detect duplicate default table definition" if @default_table

--- a/test/plugin/test_out_sql.rb
+++ b/test/plugin/test_out_sql.rb
@@ -38,7 +38,8 @@ class SqlOutputTest < Test::Unit::TestCase
       database: "fluentd_test",
       username: "fluentd",
       password: "fluentd",
-      remove_tag_suffix: /^db/
+      remove_tag_suffix: /^db/,
+      enable_fallback: true
     }
     actual = {
       host: d.instance.host,
@@ -47,7 +48,8 @@ class SqlOutputTest < Test::Unit::TestCase
       database: d.instance.database,
       username: d.instance.username,
       password: d.instance.password,
-      remove_tag_suffix: d.instance.remove_tag_prefix
+      remove_tag_suffix: d.instance.remove_tag_prefix,
+      enable_fallback: d.instance.enable_fallback
     }
     assert_equal(expected, actual)
     assert_empty(d.instance.tables)


### PR DESCRIPTION
@okkez says that some users want to use secondary immediately instead of fallback one-by-one importing when querying error occurred.