### PR TITLE
Fixed timestamp attribute serialization

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -92,6 +92,8 @@ module Fluent
             v = send(n)
             if v.respond_to?(:to_msgpack)
               v
+            elsif v.is_a? Time
+              v.strftime('%Y-%m-%d %H:%M:%S.%6N%z')
             else
               v.to_s
             end


### PR DESCRIPTION
Fix issue #24 

It is an issue of convert `Time` object to string ([line 96](https://github.com/fluent/fluent-plugin-sql/blob/master/lib/fluent/plugin/in_sql.rb#L96))
We can check whether the value is `Time` object and apply `time_format` for it

