### PR TITLE
Remove timezone on time format as it violated with BigQuery timeformat

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -93,7 +93,7 @@ module Fluent
             if v.respond_to?(:to_msgpack)
               v
             elsif v.is_a? Time
-              v.strftime('%Y-%m-%d %H:%M:%S.%6N%z')
+              v.strftime('%Y-%m-%d %H:%M:%S.%6N')
             else
               v.to_s
             end


### PR DESCRIPTION
Hi @repeatedly 
This PR aim to fix the error when streaming to BigQuery, related to this PR #45 
```<Google::Apis::BigqueryV2::ErrorProto:0x007fd4aa24d8b8 @debug_info=\“generic::invalid_argument: Could not parse ‘2017-03-13 07:21:09.177000+0000’ as a timestamp. Required format is YYYY-MM-DD HH:MM[:SS[.SSSSSS]]\“, @location=\“created_at\“, @message=\“Could not parse ‘2017-03-13 07:21:09.177000+0000’ as a timestamp. Required format is YYYY-MM-DD HH:MM[:SS[.SSSSSS]]\“, @reason=\“invalid\“>], @index=1>]”```

