### PR TITLE
Upgrade ActiveRecord to 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
   postgresql: "9.4"
 
 rvm:
-  - 2.1
   - 2.2.9
   - 2.3.6
   - 2.4.3

--- a/fluent-plugin-sql.gemspec
+++ b/fluent-plugin-sql.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |gem|
   gem.license = "Apache-2.0"
 
   gem.add_dependency "fluentd", [">= 0.12.17", "< 2"]
-  gem.add_dependency 'activerecord', "~> 4.2"
+  gem.add_dependency 'activerecord', "~> 5.1"
   gem.add_dependency 'activerecord-import', "~> 0.7"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", "~> 3.1.0"
   gem.add_development_dependency "test-unit-rr"
   gem.add_development_dependency "test-unit-notify"
-  gem.add_development_dependency "pg", '~> 0.21.0'
+  gem.add_development_dependency "pg", '~> 1.0'
 end

--- a/fluent-plugin-sql.gemspec
+++ b/fluent-plugin-sql.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', "~> 5.1"
   gem.add_dependency 'activerecord-import', "~> 0.7"
   gem.add_development_dependency "rake", ">= 0.9.2"
-  gem.add_development_dependency "test-unit", "~> 3.1.0"
+  gem.add_development_dependency "test-unit", "> 3.1.0"
   gem.add_development_dependency "test-unit-rr"
   gem.add_development_dependency "test-unit-notify"
   gem.add_development_dependency "pg", '~> 1.0'


### PR DESCRIPTION
It is necessary to use pg 1.0.0. It is no problem to upgrade them, though
pg 1.0.0 breaks backward compatibility. Those changes are covered by
ActiveRecord 5.x.

For more details about changes of pg, see
https://github.com/ged/ruby-pg/blob/master/History.rdoc#v100-2018-01-10-michael-granger-gedfaeriemudorg

Close #55