### PR TITLE
Support schema_search_path option of PostgreSQL

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -39,6 +39,8 @@ module Fluent::Plugin
     config_param :password, :string, default: nil, secret: true
     desc 'RDBMS socket path'
     config_param :socket, :string, default: nil
+    desc 'PostgreSQL schema search path'
+    config_param :schema_search_path, :string, default: nil
 
     desc 'path to a file to store last rows'
     config_param :state_file, :string, default: nil
@@ -176,6 +178,7 @@ module Fluent::Plugin
         username: @username,
         password: @password,
         socket: @socket,
+        schema_search_path: @schema_search_path,
       }
 
       # creates subclass of ActiveRecord::Base so that it can have different

--- a/lib/fluent/plugin/out_sql.rb
+++ b/lib/fluent/plugin/out_sql.rb
@@ -22,6 +22,8 @@ module Fluent::Plugin
     config_param :database, :string
     desc 'RDBMS socket path'
     config_param :socket, :string, default: nil
+    desc 'PostgreSQL schema search path'
+    config_param :schema_search_path, :string, default: nil
     desc 'remove the given prefix from the events'
     config_param :remove_tag_prefix, :string, default: nil
     desc 'enable fallback'
@@ -187,6 +189,7 @@ module Fluent::Plugin
         username: @username,
         password: @password,
         socket: @socket,
+        schema_search_path: @schema_search_path,
       }
 
       @base_model = Class.new(ActiveRecord::Base) do

--- a/test/plugin/test_in_sql.rb
+++ b/test/plugin/test_in_sql.rb
@@ -18,6 +18,8 @@ class SqlInputTest < Test::Unit::TestCase
     username fluentd
     password fluentd
 
+    schema_search_path public
+
     tag_prefix db
 
     <table>
@@ -41,6 +43,7 @@ class SqlInputTest < Test::Unit::TestCase
       database: "fluentd_test",
       username: "fluentd",
       password: "fluentd",
+      schema_search_path: "public",
       tag_prefix: "db"
     }
     actual = {
@@ -50,6 +53,7 @@ class SqlInputTest < Test::Unit::TestCase
       database: d.instance.database,
       username: d.instance.username,
       password: d.instance.password,
+      schema_search_path: d.instance.schema_search_path,
       tag_prefix: d.instance.tag_prefix
     }
     assert_equal(expected, actual)

--- a/test/plugin/test_out_sql.rb
+++ b/test/plugin/test_out_sql.rb
@@ -18,6 +18,8 @@ class SqlOutputTest < Test::Unit::TestCase
     username fluentd
     password fluentd
 
+    schema_search_path public
+
     remove_tag_prefix db
 
     <table>
@@ -39,6 +41,7 @@ class SqlOutputTest < Test::Unit::TestCase
       database: "fluentd_test",
       username: "fluentd",
       password: "fluentd",
+      schema_search_path: 'public',
       remove_tag_suffix: /^db/,
       enable_fallback: true
     }
@@ -49,6 +52,7 @@ class SqlOutputTest < Test::Unit::TestCase
       database: d.instance.database,
       username: d.instance.username,
       password: d.instance.password,
+      schema_search_path: d.instance.schema_search_path,
       remove_tag_suffix: d.instance.remove_tag_prefix,
       enable_fallback: d.instance.enable_fallback
     }


### PR DESCRIPTION
Problem
===


fluent-plugin-sql does not support PostgreSQL's schema feature. It does not have any feature to change search path of schema.


Solution
===

Add `schema_search_path` option to the plugins.

Documentations
===



* https://www.postgresql.org/docs/9.1/ddl-schemas.html
* https://apidock.com/rails/ActiveRecord/ConnectionAdapters/PostgreSQL/SchemaStatements/schema_search_path%3D


Note
=====


We actually another patch for our product. https://github.com/pocke/fluent-plugin-sql/commit/75426899764b695a1439cd5520bedd190d0befb6
Because we use fluentd v0.12.x, so we should apply the patch to fluent-plugin-sql v0.6.1.
