### PR TITLE
Feature/add support for state to s3

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,10 @@ jobs:
         os:
           - ubuntu-latest
     services:
+      minio:
+        image: minio/minio:latest
+        ports:
+          - 9000:9000
       postgres:
         image: postgres:${{ matrix.postgres }}
         ports:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,13 +14,6 @@ jobs:
         os:
           - ubuntu-latest
     services:
-      minio:
-        image: minio/minio:latest
-        volumes:
-          - data:/data
-        ports:
-          - 9000:9000
-        command: server /data
       postgres:
         image: postgres:${{ matrix.postgres }}
         ports:
@@ -48,9 +41,12 @@ jobs:
         psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE fluentd_test OWNER fluentd;"
     - name: prepare minio s3
       run: |
+        wget https://dl.minio.io/server/minio/release/linux-amd64/minio
+        chmod +x minio
+        2>/dev/null 1>/dev/null sudo ./minio server /minio&
         wget https://dl.minio.io/client/mc/release/linux-amd64/mc
         chmod +x mc
-        ./mc config host add minio http://minio:9000 minioadmin minioadmin
+        ./mc config host add minio http://localhost:9000 minioadmin minioadmin
         ./mc mb minio/fluentd-test12345
     - name: unit testing
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,8 +16,11 @@ jobs:
     services:
       minio:
         image: minio/minio:latest
+        volumes:
+          - data:/data
         ports:
           - 9000:9000
+        command: server /data
       postgres:
         image: postgres:${{ matrix.postgres }}
         ports:
@@ -43,6 +46,12 @@ jobs:
       run: |
         psql -h localhost -p 5432 -U postgres -c "CREATE ROLE fluentd WITH LOGIN ENCRYPTED PASSWORD 'fluentd';"
         psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE fluentd_test OWNER fluentd;"
+    - name: prepare minio s3
+      run: |
+        wget https://dl.minio.io/client/mc/release/linux-amd64/mc
+        chmod +x mc
+        ./mc config host add minio http://minio:9000 minioadmin minioadmin
+        ./mc mb minio/fluentd-test12345
     - name: unit testing
       run: |
         gem install bundler rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ before_install:
 before_script:
   - psql -U postgres -c "CREATE ROLE fluentd WITH LOGIN ENCRYPTED PASSWORD 'fluentd';"
   - psql -U postgres -c "CREATE DATABASE fluentd_test OWNER fluentd;"
+  - wget https://dl.minio.io/server/minio/release/linux-amd64/minio
+  - chmod +x minio
+  - sudo ./minio server /minio
+  - wget https://dl.minio.io/client/mc/release/linux-amd64/mc
+  - chmod +x mc
+  - ./mc config host add minio http://127.0.0.1:9000 minioadmin minioadmin
+  - ./mc mb minio/fluentd-test12345
 
 script: bundle exec rake test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - psql -U postgres -c "CREATE DATABASE fluentd_test OWNER fluentd;"
   - wget https://dl.minio.io/server/minio/release/linux-amd64/minio
   - chmod +x minio
-  - sudo ./minio server /minio
+  - 2>/dev/null 1>/dev/null sudo ./minio server /minio&
   - wget https://dl.minio.io/client/mc/release/linux-amd64/mc
   - chmod +x mc
   - ./mc config host add minio http://127.0.0.1:9000 minioadmin minioadmin

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -2,6 +2,6 @@ source "http://rubygems.org"
 
 gem 'json', '= 1.8.6'
 gem 'fluentd', '~> 0.12.0'
-gem 'aws-sdk-s3', '~> 3'
+gem 'aws-sdk-s3', '~> 1'
 
 gemspec

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -2,6 +2,6 @@ source "http://rubygems.org"
 
 gem 'json', '= 1.8.6'
 gem 'fluentd', '~> 0.12.0'
-gem 'aws-sdk', '~> 3'
+gem 'aws-sdk-s3', '~> 3'
 
 gemspec

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -2,5 +2,6 @@ source "http://rubygems.org"
 
 gem 'json', '= 1.8.6'
 gem 'fluentd', '~> 0.12.0'
+gem 'aws-sdk', '~> 3'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ SELECT * FROM *table* WHERE *update\_column* > *last\_update\_column\_value* ORD
 What you need to configure is *update\_column*. The column should be an incremental column (such as AUTO\_ INCREMENT primary key) so that this plugin reads newly INSERTed rows. Alternatively, you can use a column incremented every time when you update the row (such as `last_updated_at` column) so that this plugin reads the UPDATEd rows as well.
 If you omit to set *update\_column* parameter, it uses primary key.
 
-It stores last selected rows to a file (named *state\_file*) to not forget the last row when Fluentd restarts. If you want to use and AWS S3 object store to hold this information, define the bucket name and key and AWS region. Also make sure AWS credentials are provided through the environment. See https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html
+It stores last selected rows to a file (named *state\_file*) to not forget the last row when Fluentd restarts. If you want to use and AWS S3 object store to hold this information, define the bucket name and key and AWS region. Also make sure AWS credentials are provided through the environment. See https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html. If the bucket_key does not exist yet, you will receive this error: 'Aws::S3::Errors::NoSuchKey: The specified key does not exist'
 
 ## Input: Configuration
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ SELECT * FROM *table* WHERE *update\_column* > *last\_update\_column\_value* ORD
 What you need to configure is *update\_column*. The column should be an incremental column (such as AUTO\_ INCREMENT primary key) so that this plugin reads newly INSERTed rows. Alternatively, you can use a column incremented every time when you update the row (such as `last_updated_at` column) so that this plugin reads the UPDATEd rows as well.
 If you omit to set *update\_column* parameter, it uses primary key.
 
-It stores last selected rows to a file (named *state\_file*) to not forget the last row when Fluentd restarts.
+It stores last selected rows to a file (named *state\_file*) to not forget the last row when Fluentd restarts. If you want to use and AWS S3 object store to hold this information, define the bucket name and key and AWS region. Also make sure AWS credentials are provided through the environment. See https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html
 
 ## Input: Configuration
 
@@ -60,6 +60,10 @@ It stores last selected rows to a file (named *state\_file*) to not forget the l
       select_limit 500     # optional
 
       state_file /var/run/fluentd/sql_state
+
+      s3_bucket_name mybucketname   # optional
+      s3_bucket_key mybucketkey     # optional
+      aws_region myregion           # optional
 
       <table>
         table table1
@@ -89,6 +93,9 @@ It stores last selected rows to a file (named *state\_file*) to not forget the l
 * **select_interval** interval to run SQLs (optional)
 * **select_limit** LIMIT of number of rows for each SQL (optional)
 * **state_file** path to a file to store last rows
+* **s3_bucket_name** S3 bucket name in AWS where to store sql state information (optional)
+* **s3_bucket_key** S3 bucket key in AWS which will contain the actual sql information (optional)
+* **aws_region** AWS region where the bucket is located (optional)
 * **all_tables** reads all tables instead of configuring each tables in \<table\> sections
 
 \<table\> sections:
@@ -138,7 +145,7 @@ This plugin takes advantage of ActiveRecord underneath. For `host`, `port`, `dat
         # the message comes in with the tag my.rdb.hello.world, "remove_tag_prefix my.rdb"
         # makes it "hello.world", which gets matched here because of "pattern hello.*".
       </table>
-      
+
       <table hello.world>
         table table3
         # This is the second non-default table. You can have as many non-default tables

--- a/fluent-plugin-sql.gemspec
+++ b/fluent-plugin-sql.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit-rr"
   gem.add_development_dependency "test-unit-notify"
   gem.add_development_dependency "pg", '~> 1.0'
+  gem.add_development_dependency "aws-sdk", '~> 3'
 end

--- a/fluent-plugin-sql.gemspec
+++ b/fluent-plugin-sql.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit-rr"
   gem.add_development_dependency "test-unit-notify"
   gem.add_development_dependency "pg", '~> 1.0'
-  gem.add_development_dependency "aws-sdk", '~> 3'
+  gem.add_development_dependency "aws-sdk-s3", '~> 1'
 end

--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -336,20 +336,15 @@ module Fluent::Plugin
         @region = aws_region
 
         s3_client = Aws::S3::Client.new(region: @region)
-        resp = s3_client.get_object(bucket:@bucket_name, key:@object_key)
-        if resp
-          @data = YAML.load(resp.body.read)
-          print @data
+        s3response = s3_client.get_object(bucket:@bucket_name, key:@object_key)
+        if s3response
+          @data = YAML.load(s3response.body.read)
           if @data == false || @data == []
-            # this happens if an users created an empty file accidentally
             @data = {}
           end
         else
           @data = {}
         end
-
-        @data = {}
-
       end
 
       def last_records
@@ -375,9 +370,5 @@ module Fluent::Plugin
 
       end
     end
-
-
-
   end
-
 end

--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -50,7 +50,7 @@ module Fluent::Plugin
     config_param :s3_bucket_name, :string, default: nil
     desc 'S3 bucket key (optional)'
     config_param :s3_bucket_key, :string, default: nil
-    desc 'AWS regions(optional)'
+    desc 'AWS region (optional)'
     config_param :aws_region, :string, default: nil
     desc 'prefix of tags of events. actual tag will be this_tag_prefix.tables_tag (optional)'
     config_param :tag_prefix, :string, default: nil
@@ -334,7 +334,7 @@ module Fluent::Plugin
         @bucket_name = s3_bucket_name
         @object_key = s3_bucket_key
         @region = aws_region
-        
+
         s3_client = Aws::S3::Client.new(region: @region)
         resp = s3_client.get_object(bucket:@bucket_name, key:@object_key)
         if resp

--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -334,6 +334,22 @@ module Fluent::Plugin
         @bucket_name = s3_bucket_name
         @object_key = s3_bucket_key
         @region = aws_region
+        
+        s3_client = Aws::S3::Client.new(region: @region)
+        resp = s3_client.get_object(bucket:@bucket_name, key:@object_key)
+        if resp
+          @data = YAML.load(resp.body.read)
+          print @data
+          if @data == false || @data == []
+            # this happens if an users created an empty file accidentally
+            @data = {}
+          end
+        else
+          @data = {}
+        end
+
+        @data = {}
+
       end
 
       def last_records

--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -189,7 +189,7 @@ module Fluent::Plugin
 
     def start
       if @s3_bucket_name
-        @state_store = S3StateStore.new
+        @state_store = S3StateStore.new(@s3_bucket_name,@s3_bucket_key,@aws_region)
       else
         @state_store = @state_file.nil? ? MemoryStateStore.new : StateStore.new(@state_file)
       end

--- a/test/plugin/test_in_sql.rb
+++ b/test/plugin/test_in_sql.rb
@@ -18,6 +18,10 @@ class SqlInputTest < Test::Unit::TestCase
     username fluentd
     password fluentd
 
+    s3_bucket_name joustie
+    s3_bucket_key test.test
+    aws_region eu-west-1
+
     schema_search_path public
 
     tag_prefix db

--- a/test/plugin/test_in_sql_s3.rb
+++ b/test/plugin/test_in_sql_s3.rb
@@ -1,7 +1,7 @@
 require "helper"
 require "fluent/test/driver/input"
 
-class SqlInputTest < Test::Unit::TestCase
+class SqlInputTestS3 < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
   end
@@ -17,6 +17,10 @@ class SqlInputTest < Test::Unit::TestCase
 
     username fluentd
     password fluentd
+
+    s3_bucket_name joustie
+    s3_bucket_key test.test
+    aws_region eu-west-1
 
     schema_search_path public
 
@@ -66,9 +70,9 @@ class SqlInputTest < Test::Unit::TestCase
 
   def test_message
     d = create_driver(CONFIG + "select_interval 1")
-    Message.create!(message: "message 1")
-    Message.create!(message: "message 2")
-    Message.create!(message: "message 3")
+    Message.create!(message: "message 4")
+    Message.create!(message: "message 5")
+    Message.create!(message: "message 6")
 
     d.end_if do
       d.record_count >= 3
@@ -77,14 +81,14 @@ class SqlInputTest < Test::Unit::TestCase
 
     assert_equal("db.logs", d.events[0][0])
     expected = [
-      [d.events[0][1], "message 1"],
-      [d.events[1][1], "message 2"],
-      [d.events[2][1], "message 3"],
+      [d.events[0][1], "message 4"],
+      [d.events[1][1], "message 5"],
+      [d.events[2][1], "message 6"],
     ]
     actual = [
-      [Fluent::EventTime.parse(d.events[0][2]["updated_at"]), d.events[0][2]["message"]],
-      [Fluent::EventTime.parse(d.events[1][2]["updated_at"]), d.events[1][2]["message"]],
-      [Fluent::EventTime.parse(d.events[2][2]["updated_at"]), d.events[2][2]["message"]],
+      [Fluent::EventTime.parse(d.events[4][2]["updated_at"]), d.events[4][2]["message"]],
+      [Fluent::EventTime.parse(d.events[5][2]["updated_at"]), d.events[5][2]["message"]],
+      [Fluent::EventTime.parse(d.events[6][2]["updated_at"]), d.events[6][2]["message"]],
     ]
     assert_equal(expected, actual)
   end

--- a/test/plugin/test_in_sql_s3.rb
+++ b/test/plugin/test_in_sql_s3.rb
@@ -4,6 +4,25 @@ require "fluent/test/driver/input"
 class SqlInputTestS3 < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
+
+    @bucket_name = 'fluentd-test12345'
+    # creating the object_key for the test
+    s3_client = Aws::S3::Client.new(region: 'us-east-1')
+
+        response = s3_client.put_object(
+          bucket:  @bucket_name,
+          key: 'sql.state' ,
+          body: ''
+        )
+        if response.etag
+          return true
+        else
+          return false
+        end
+        rescue StandardError => e
+          puts "Error creating object: #{e.message}"
+        return false
+
   end
 
   def teardown
@@ -18,7 +37,7 @@ class SqlInputTestS3 < Test::Unit::TestCase
     username fluentd
     password fluentd
 
-    s3_bucket_name fluentd_test
+    s3_bucket_name fluentd-test12345
     s3_bucket_key sql.state
     aws_region us-east-1
 
@@ -94,7 +113,7 @@ class SqlInputTestS3 < Test::Unit::TestCase
 
     # Test if last updated recordid is saved in state file on S3
     s3_client = Aws::S3::Client.new(region: 'us-east-1')
-    resp = s3_client.get_object(bucket:'fluentd_test', key:'sql.state')
+    resp = s3_client.get_object(bucket:@bucket_name, key:'sql.state')
     if resp
       @data = YAML.load(resp.body.read)
     else


### PR DESCRIPTION
Hi,

This PR is to add S3 support for storing SQL state when using the input configuration. I have also added a unit test and altered the Travis configuration to load Minio (mocking S3) in a test context.

Let me also add the reason why I worked on this:
We spin up EC2 images which have Fluentd with the SQL plugin to monitor certain views and send added records to an SQS queue as a transformed message.
Currently, the SQL state is saved locally on that EC2 instance. The instance could be destroyed and recreated so the state could be lost. There are many ways to have this state file persisted, but an easy one I could think of was to put it in S3, that is why I created this PR.