### PR TITLE
Make table time_format configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ It stores last selected rows to a file (named *state\_file*) to not forget the l
         tag table2  # optional
         update_column updated_at
         time_column updated_at  # optional
+        time_format %Y-%m-%d %H:%M:%S.%6N # optional
       </table>
 
       # detects all tables instead of <table> sections
@@ -94,6 +95,7 @@ It stores last selected rows to a file (named *state\_file*) to not forget the l
 * **update_column**: see above description
 * **time_column** (optional): if this option is set, this plugin uses this column's value as the the event's time. Otherwise it uses current time.
 * **primary_key** (optional): if you want to get data from the table which doesn't have primary key like PostgreSQL's View, set this parameter.
+* **time_format** (optional): if you want to specify the format of the date used in the query, useful when using alternative adapters which have restrictions on format
 
 ## Input: Limitation
 

--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -74,27 +74,22 @@ module Fluent::Plugin
         # creates a model for this table
         table_name = @table
         primary_key = @primary_key
-        time_formats = Fluent::VariableStore.fetch_or_build(:time_formats)
-        time_formats[table_name] = @time_format
+        time_format = @time_format
 
         @model = Class.new(base_model) do
           self.table_name = table_name
           self.inheritance_column = '_never_use_'
           self.primary_key = primary_key if primary_key
+          self.const_set(:TIME_FORMAT, time_format)
 
           #self.include_root_in_json = false
-
-          def time_format
-            time_formats = Fluent::VariableStore.fetch_or_build(:time_formats)
-            time_formats[self.class.table_name]
-          end
 
           def read_attribute_for_serialization(n)
             v = send(n)
             if v.respond_to?(:to_msgpack)
               v
             elsif v.is_a? Time
-              v.strftime(time_format)
+              v.strftime(self.class::TIME_FORMAT)
             else
               v.to_s
             end


### PR DESCRIPTION
## Issue

When using the plugin with MySQL, the date comparison gets rejected due to the timezone.

![Screenshot 2021-09-30 at 2 40 10 PM](https://user-images.githubusercontent.com/1822532/135780270-e2fec90f-53ed-42b0-ad93-9e5cced046bd.png)

Running the following SQL with a timezone for `last_update_column_value` would cause this

```sql
SELECT * FROM table WHERE update_column > last_update_column_value
```

## Fix

This PR makes the time format configurable, allowing us to override it **per table.**

Example configuration

```xml
<source>
  @type sql
   
   # ...
  
  <table>
    table my_table
    tag my_tag
    update_column updated_at
    time_format %Y-%m-%d %H:%M:%S.%6N
  </table>
</source>
```

Note: I kept the pre-defined format as it was, to avoid any backwards compatibility issue

@repeatedly 