### PR TITLE
Remove test-unit-notify from development dependency to speed up testing

### DIFF
--- a/fluent-plugin-sql.gemspec
+++ b/fluent-plugin-sql.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", "> 3.1.0"
   gem.add_development_dependency "test-unit-rr"
+  gem.add_development_dependency "test-unit-notify"
   gem.add_development_dependency "pg", '~> 1.0'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require "test/unit"
 require "test/unit/rr"
+require "test/unit/notify" unless ENV['CI']
 require "fluent/test"
 require "fluent/plugin/out_sql"
 require "fluent/plugin/in_sql"


### PR DESCRIPTION
I have noticed that when I run `bundle exec rake test` locally, it appears to freeze after the test is finished.
In my environment, it freezes for about 10 seconds.

This PR solves the problem.
It seems that test-unit-notify is not maintained, so it can be safely removed.

It also suppresses the following error messages that were displayed in GitHub Actions.

* Without this commit
  ```
  ...
  Finished in 12.337743057 seconds.
  -------------------------------------------------------------------------------
  8 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
  100% passed
  -------------------------------------------------------------------------------
  0.65 tests/s, 1.78 assertions/s
  /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/definition.rb:496:in `materialize': Could not find rake-13.0.6, test-unit-3.5.0, test-unit-rr-1.0.5, test-unit-notify-1.0.4, pg-1.2.3, fluentd-1.14.1, activerecord-6.1.4.1, activerecord-import-1.2.0, power_assert-2.0.1, rr-3.0.8, cool.io-1.7.1, http_parser.rb-0.7.0, msgpack-1.4.2, serverengine-2.2.4, sigdump-0.2.4, strptime-0.2.5, tzinfo-2.0.4, tzinfo-data-1.2021.4, webrick-1.7.0, yajl-ruby-1.4.1, activemodel-6.1.4.1, activesupport-6.1.4.1, concurrent-ruby-1.1.9, i18n-1.8.10, minitest-5.14.4, zeitwerk-2.5.1 in any of the sources (Bundler::GemNotFound)
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/definition.rb:234:in `specs_for'
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/runtime.rb:18:in `setup'
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler.rb:149:in `setup'
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/setup.rb:20:in `block in <top (required)>'
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/ui/shell.rb:136:in `with_level'
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/ui/shell.rb:88:in `silence'
    from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.29/lib/bundler/setup.rb:20:in `<top (required)>'
    from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
    from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
  ```

* With this commit
  ```
  ...
  Finished in 12.281693577 seconds.
  -------------------------------------------------------------------------------
  8 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
  100% passed
  -------------------------------------------------------------------------------
  0.65 tests/s, 1.79 assertions/s
  ```

I also noticed this repository does not have `.gitignore`, so I committed it.