### PR TITLE
CI: Remove needless continue-on-error

### DIFF
--- a/.github/workflows/linux-ruby-head.yml
+++ b/.github/workflows/linux-ruby-head.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -15,7 +14,6 @@ jobs:
         postgres: [ '16', '15', '14', '13', '12' ]
         os:
           - ubuntu-latest
-        experimental: [true]
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -16,7 +15,6 @@ jobs:
         postgres: [ '16', '15', '14', '13', '12' ]
         os:
           - ubuntu-latest
-        experimental: [false]
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}


### PR DESCRIPTION
Sicne we moved test on Ruby head to a separated workflow, so we don't need contoinue-on-error anymore.