### PR TITLE
Use isolated connection configurations in the output plugin

### DIFF
--- a/lib/fluent/plugin/out_sql.rb
+++ b/lib/fluent/plugin/out_sql.rb
@@ -206,7 +206,7 @@ module Fluent::Plugin
       end
 
       SQLOutput.const_set("BaseModel_#{rand(1 << 31)}", @base_model)
-      ActiveRecord::Base.establish_connection(config)
+      @base_model.establish_connection(config)
 
       # ignore tables if TableElement#init failed
       @tables.reject! do |te|
@@ -224,7 +224,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      ActiveRecord::Base.connection_pool.with_connection do
+      @base_model.connection_pool.with_connection do
 
         @tables.each { |table|
           tag = format_tag(chunk.metadata.tag)


### PR DESCRIPTION
Modify to use isolated connection configurations for each plugin instance. 

The previous implementation had an issue where incorrect connections were used due to ActiveRecord's connection pooling mechanism when the output plugin was used multiple times.