### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/lib/fluent/plugin/out_sql.rb
+++ b/lib/fluent/plugin/out_sql.rb
@@ -99,7 +99,7 @@ module Fluent::Plugin
             columns |= new_record.keys
             records << @model.new(new_record)
           rescue => e
-            args = {error: e, table: @table, record: Yajl.dump(data)}
+            args = {error: e, table: @table, record: JSON.generate(data)}
             @log.warn "Failed to create the model. Ignore a record:", args
           end
         }


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.