### PR TITLE
in_sql: add nil guard in shutdown

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -248,8 +248,10 @@ module Fluent::Plugin
 
     def shutdown
       @stop_flag = true
-      $log.debug "Waiting for thread to finish"
-      @thread.join
+      if @thread
+        $log.debug "Waiting for thread to finish"
+        @thread.join
+      end
     end
 
     def thread_main


### PR DESCRIPTION
`@thread` is assigned only on the last line of `#start`,
 so any shutdown that runs on an instance whose `#start` never reached that line calls `@thread.join` on nil and raises "undefined method `join' for nil:NilClass".

Fix #154