### PR TITLE
in_sql: fix all_tables crash by passing a Config::Element to TableElement#configure

### DIFF
--- a/lib/fluent/plugin/in_sql.rb
+++ b/lib/fluent/plugin/in_sql.rb
@@ -219,11 +219,10 @@ module Fluent::Plugin
             nil
           else
             te = TableElement.new
-            te.configure({
+            te.configure(Fluent::Config::Element.new('table', '', {
               'table' => table_name,
               'tag' => table_name,
-              'update_column' => nil,
-            })
+            }, []))
             te
           end
         end.compact

--- a/test/plugin/test_in_sql.rb
+++ b/test/plugin/test_in_sql.rb
@@ -30,6 +30,22 @@ class SqlInputTest < Test::Unit::TestCase
     </table>
   ]
 
+  ALL_TABLES_CONFIG = %[
+    adapter postgresql
+    host localhost
+    port 5432
+    database fluentd_test
+
+    username fluentd
+    password fluentd
+
+    schema_search_path public
+
+    tag_prefix db
+
+    all_tables true
+  ]
+
   def create_driver(conf = CONFIG)
     Fluent::Test::Driver::Input.new(Fluent::Plugin::SQLInput).configure(conf)
   end
@@ -62,6 +78,18 @@ class SqlInputTest < Test::Unit::TestCase
     messages = tables.first
     assert_equal("messages", messages.table)
     assert_equal("logs", messages.tag)
+  end
+
+  def test_all_tables
+    d = create_driver(ALL_TABLES_CONFIG)
+    d.instance.start
+    begin
+      table_names = d.instance.instance_variable_get(:@tables).map(&:table)
+      assert { table_names.include?("messages") }
+      assert { !table_names.include?("schema_migrations") }
+    ensure
+      d.instance.shutdown
+    end
   end
 
   def test_message

--- a/test/plugin/test_in_sql.rb
+++ b/test/plugin/test_in_sql.rb
@@ -86,7 +86,7 @@ class SqlInputTest < Test::Unit::TestCase
     begin
       table_names = d.instance.instance_variable_get(:@tables).map(&:table)
       assert { table_names.include?("messages") }
-      assert { !table_names.include?("schema_migrations") }
+      assert { table_names.none? { |table_name| table_name.match?(Fluent::Plugin::SQLInput::SKIP_TABLE_REGEXP) }}
     ensure
       d.instance.shutdown
     end


### PR DESCRIPTION
`all_tables` built each discovered table by passing a plain Hash to `TableElement#configure`,
but `Fluent::Configurable#configure` expects a `Fluent::Config::Element` and calls `#corresponding_proxies` on it,
so every discovered table raised `NoMethodError` and `#start` failed.
Wrap the attributes in a `Fluent::Config::Element`.

`update_column` defaults to `nil`, so it no longer needs to be passed explicitly.

Fixes #177